### PR TITLE
store base_ag when marginalizing a dag using new implementation

### DIFF
--- a/graphical_models/classes/dags/dag.py
+++ b/graphical_models/classes/dags/dag.py
@@ -2212,11 +2212,14 @@ class DAG:
             # for node in latent_nodes:
             #     ag.remove_node(node, ignore_error=True)
 
+            base_ag = AncestralGraph(nodes=self._nodes, directed=self._arcs)
             ag = AncestralGraph(nodes=self._nodes, directed=self._arcs)
-            ancestor_dict = ag.ancestor_dict()
+            ancestor_dict = base_ag.ancestor_dict()
+            
             for i, j in itr.combinations(self._nodes - latent_nodes, 2):
                 S = (ancestor_dict[i] | ancestor_dict[j]) - {i, j} - latent_nodes
-                if not ag.has_any_edge(i, j) and not ag.msep(i, j, S):
+            
+                if not ag.has_any_edge(i, j) and not base_ag.msep(i, j, S):
                     if i in ancestor_dict[j]:
                         ag._add_directed(i, j)
                     elif j in ancestor_dict[i]:


### PR DESCRIPTION
## Fix: Use separate graphs for testing and construction in marginal_mag

**Thanks for creating and maintaining this package!**

### The Issue

The `marginal_mag` method (when `new=True`) modifies the graph it's testing for m-separation:

```python
ag = AncestralGraph(nodes=self._nodes, directed=self._arcs)
for i, j in itr.combinations(self._nodes - latent_nodes, 2):
    S = (ancestor_dict[i] | ancestor_dict[j]) - {i, j} - latent_nodes
    if not ag.has_any_edge(i, j) and not ag.msep(i, j, S):
        # Problem: modifying ag here may affect subsequent m-separation tests
        ag._add_directed(i, j)  # or _add_bidirected
```

The ancestral criterion theorem assumes you're testing against the original structure, not the partially-constructed one.

**I couldn't actually break this** - even after testing by spending quite a few LLM tokens for brute force examples, I could not find a case where modifying a graph during the iteration produces incorrect results. The ancestral criterion appears robust enough to handle my examples, but testing m-separation on a graph one is actively modifying feels wrong. 

### The Fix

Keep two graphs: original one for testing, one for building the result.

### Performance Impact

Speed difference is negligible. We're creating one extra AncestralGraph object at the start - everything else stays the same. The overhead is storing two graph objects instead of one should be trivial compared to the (O(n²)?) m-separation tests being performed. There might even be a tiny speedup since graph remains unmodified and could theoretically benefit from better cache locality. Unmeasurable in practice.